### PR TITLE
Integer() changed to Utils.number to handle octal values

### DIFF
--- a/lib/cronex/description/day_of_week.rb
+++ b/lib/cronex/description/day_of_week.rb
@@ -9,7 +9,7 @@ module Cronex
       end
 
       if Cronex::Utils.number?(exp)
-        dow_num = Integer(exp)
+        dow_num = Cronex::Utils.number(exp)
         zero_based_dow = options[:zero_based_dow]
         invalid_dow = !zero_based_dow && dow_num <= 1
         if invalid_dow || (zero_based_dow && dow_num == 0)

--- a/lib/cronex/description/month.rb
+++ b/lib/cronex/description/month.rb
@@ -1,7 +1,7 @@
 module Cronex
   class MonthDescription < Description
     def single_item_description(expression)
-      resources.get(DateTime.new(Time.now.year, Integer(expression), 1).strftime('%B').downcase)
+      resources.get(DateTime.new(Time.now.year, Cronex::Utils.number(expression), 1).strftime('%B').downcase)
     end
 
     def interval_description_format(expression)

--- a/lib/cronex/description/year.rb
+++ b/lib/cronex/description/year.rb
@@ -1,7 +1,7 @@
 module Cronex
   class YearDescription < Description
     def single_item_description(expression)
-      DateTime.new(Integer(expression)).strftime('%Y')
+      DateTime.new(Cronex::Utils.number(expression)).strftime('%Y')
     end
 
     def interval_description_format(expression)

--- a/lib/cronex/exp_descriptor.rb
+++ b/lib/cronex/exp_descriptor.rb
@@ -113,7 +113,7 @@ module Cronex
       else
         match = exp.match(/(\d{1,2}W)|(W\d{1,2})/)
         if match
-          day_num = Integer(match[0].gsub('W', ''))
+          day_num = Cronex::Utils.number(match[0].gsub('W', ''))
           day_str = day_num == 1 ? resources.get('first_weekday') : format(resources.get('weekday_nearest_day'), day_num)
           description = format(', ' + resources.get('on_the_of_the_month'), day_str)
         else

--- a/lib/cronex/utils.rb
+++ b/lib/cronex/utils.rb
@@ -11,7 +11,14 @@ module Cronex
     end
 
     def number?(str)
-      Integer(str) rescue nil
+      Cronex::Utils.number(str) rescue nil
+    end
+
+    def number(str)
+      # Because fo following Integer() behavior
+      # https://www.ruby-forum.com/topic/62141
+      str.sub!(/^0+/, '')
+      Integer(str)
     end
 
     def day_of_week_name(number)
@@ -27,14 +34,14 @@ module Cronex
     end
 
     def format_time(hour_expression, minute_expression, second_expression = '')
-      hour = Integer(hour_expression)
+      hour = Cronex::Utils.number(hour_expression)
       period = hour >= 12 ? 'PM' : 'AM'
       hour -= 12 if hour > 12
-      minute = Integer(minute_expression)
+      minute = Cronex::Utils.number(minute_expression)
       minute = format('%02d', minute)
       second = ''
       if Cronex::Utils.present?(second_expression)
-        second = Integer(second_expression)
+        second = Cronex::Utils.number(second_expression)
         second = ':' + format('%02d', second)
       end
       format('%s:%s%s %s', hour, minute, second, period)


### PR DESCRIPTION
In Integer(): the leading zero leads Ruby to think it's octal, but 8 & 9 isn't valid in an octal number.
https://www.ruby-forum.com/topic/62141

So in some of following expressions, it would raise errors
```
# would raise exception
Integer("08") #=> ArgumentError: invalid value for Integer(): "08"
Cronex::ExpressionDescriptor.new("00 09 * * 7").description #=> ArgumentError: invalid value for Integer(): "09"

# works fine
Cronex::ExpressionDescriptor.new("00 9 * * 7").description #=>  "At 9:00 AM, only on Sunday"
```


I fixed the issue by creating new method `Cronex::Utils.number` and changed all `Integer()` with it