### PR TITLE
Fix Ranges in Hours

### DIFF
--- a/lib/cronex/utils.rb
+++ b/lib/cronex/utils.rb
@@ -33,17 +33,19 @@ module Cronex
     end
 
     def format_time(hour_expression, minute_expression, second_expression = '')
-      hour = integer(hour_expression)
-      period = hour >= 12 ? 'PM' : 'AM'
-      hour -= 12 if hour > 12
-      minute = integer(minute_expression)
-      minute = format('%02d', minute)
-      second = ''
-      if present?(second_expression)
-        second = integer(second_expression)
-        second = ':' + format('%02d', second)
-      end
-      format('%s:%s%s %s', hour, minute, second, period)
+      hour_expression.split(',').map do |hour_exp|
+        hour = integer(hour_exp)
+        period = hour >= 12 ? 'PM' : 'AM'
+        hour -= 12 if hour > 12
+        minute = integer(minute_expression)
+        minute = format('%02d', minute)
+        second = ''
+        if present?(second_expression)
+          second = integer(second_expression)
+          second = ':' + format('%02d', second)
+        end
+        format('%s:%s%s %s', hour, minute, second, period)
+      end.join(',')
     end
   end
 end

--- a/spec/exp_descriptor_en_spec.rb
+++ b/spec/exp_descriptor_en_spec.rb
@@ -311,6 +311,10 @@ module Cronex
       expect(desc('23 12 * JAN-MAR * 2013-2015')).to eq('At 12:23 PM, January through March, 2013 through 2015')
     end
 
+    it 'hours ranges' do
+      expect(desc("10,11 2,4-5 * * *")).to eq('At 10 and 11 minutes past the hour, between 2:00 AM,4:00 AM and 5:59 AM')
+    end
+
     context 'multi part range seconds:' do
       it 'multi part range seconds 2,4-5' do
         expect(desc('2,4-5 1 * * *')).to eq('Minutes 02,04 through 05 past the hour, at 1:00 AM')


### PR DESCRIPTION
`Cronex::Utils.format_time` did not support ranges in `hour_expression`. I'm not sure I fully followed the design here. As the same problems seems to be present with day of month and day of week expression segments.

But maybe this PR can be used as a starting point.

See: https://github.com/alpinweis/cronex/issues/1