### PR TITLE
Include day of week when day of month is included

### DIFF
--- a/lib/cronex/exp_descriptor.rb
+++ b/lib/cronex/exp_descriptor.rb
@@ -162,8 +162,7 @@ module Cronex
       month_desc = month_description(expression_parts)
       dow_desc = day_of_week_description(expression_parts)
       year_desc = year_description(expression_parts)
-      day_desc = expression_parts[3] == '*' ? dow_desc : dom_desc
-      description = format('%s%s%s%s', time_segment, day_desc, month_desc, year_desc)
+      description = format('%s%s%s%s%s', time_segment, dom_desc, dow_desc, month_desc, year_desc)
       description = transform_verbosity(description, options[:verbose])
       description = transform_case(description, options[:casing])
       description

--- a/spec/exp_descriptor_en_spec.rb
+++ b/spec/exp_descriptor_en_spec.rb
@@ -180,8 +180,8 @@ module Cronex
       expect(desc('23 12 15 * *')).to eq('At 12:23 PM, on day 15 of the month')
     end
 
-    it 'day of month ignores day of week' do
-      expect(desc('23 12 15 * SUN')).to eq('At 12:23 PM, on day 15 of the month')
+    it 'day of month includes day of week' do
+      expect(desc('23 12 15 * SUN')).to eq('At 12:23 PM, on day 15 of the month, only on Sunday')
     end
 
     it 'month name' do

--- a/spec/exp_descriptor_fr_spec.rb
+++ b/spec/exp_descriptor_fr_spec.rb
@@ -180,8 +180,8 @@ module Cronex
       expect(desc('23 12 15 * *')).to eq('À 12:23 PM, le 15 de chaque mois')
     end
 
-    it 'day of month ignores day of week' do
-      expect(desc('23 12 15 * SUN')).to eq('À 12:23 PM, le 15 de chaque mois')
+    it 'day of month includes day of week' do
+      expect(desc('23 12 15 * SUN')).to eq('À 12:23 PM, le 15 de chaque mois, seulement le dimanche')
     end
 
     it 'month name' do

--- a/spec/exp_descriptor_pt_BR_spec.rb
+++ b/spec/exp_descriptor_pt_BR_spec.rb
@@ -180,8 +180,8 @@ module Cronex
       expect(desc('23 12 15 * *')).to eq('Às 12:23 PM, no dia 15 do mês')
     end
 
-    it 'day of month ignores day of week' do
-      expect(desc('23 12 15 * SUN')).to eq('Às 12:23 PM, no dia 15 do mês')
+    it 'day of month includes day of week' do
+      expect(desc('23 12 15 * SUN')).to eq('Às 12:23 PM, no dia 15 do mês, todo(a) domingo')
     end
 
     it 'month name' do

--- a/spec/exp_descriptor_ro_spec.rb
+++ b/spec/exp_descriptor_ro_spec.rb
@@ -180,8 +180,8 @@ module Cronex
       expect(desc('23 12 15 * *')).to eq('La 12:23 PM, în a 15-a zi a lunii')
     end
 
-    it 'day of month ignores day of week' do
-      expect(desc('23 12 15 * SUN')).to eq('La 12:23 PM, în a 15-a zi a lunii')
+    it 'day of month includes day of week' do
+      expect(desc('23 12 15 * SUN')).to eq('La 12:23 PM, în a 15-a zi a lunii, numai duminică')
     end
 
     it 'month name' do

--- a/spec/exp_descriptor_ru_spec.rb
+++ b/spec/exp_descriptor_ru_spec.rb
@@ -180,8 +180,8 @@ module Cronex
       expect(desc('23 12 15 * *')).to eq('В 12:23 PM, 15 число месяца')
     end
 
-    it 'day of month ignores day of week' do
-      expect(desc('23 12 15 * SUN')).to eq('В 12:23 PM, 15 число месяца')
+    it 'day of month includes day of week' do
+      expect(desc('23 12 15 * SUN')).to eq('В 12:23 PM, 15 число месяца, только воскресенье')
     end
 
     it 'month name' do


### PR DESCRIPTION
looking at other implementations of this library the day of week is included even when the day of month is included.

This can be seen by visiting: https://cronexpressiondescriptor.azurewebsites.net/?expression=23+12+15+*+SUN&locale=en
([relevant code](https://github.com/bradymholt/cron-expression-descriptor/blob/master/lib/ExpressionDescriptor.cs#L159) showing day of month + day of week are always formatted )

or by running the following
`pip install cron-descriptor`
```
from cron_descriptor import get_description, ExpressionDescriptor
print(get_description('23 12 15 * SUN'))
# -> At 12:23 PM, on day 15 of the month, only on Sunday
```
([relevant code ](https://github.com/Salamek/cron-descriptor/blob/master/cron_descriptor/ExpressionDescriptor.py#L125)showing day of month + day of week are always formatted)
