### PR TITLE
Timezone support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### [0.8.0] - 2019-04-18
+* Add support for timezones
+
 ### [0.7.0] - 2018-11-22
 * Include day of week when day of month is specified
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Original Author & Credit: Brady Holt (http://www.geekytidbits.com).
  * Provides casing options (sentence, title, lower)
  * Support for non-standard non-zero-based week day numbers
  * Supports printing to locale specific human readable format
+ * Supports displaying times in specific timezones
 
 For a quick intro to cron see Quartz [Cron Tutorial](http://www.quartz-scheduler.org/documentation/quartz-1.x/tutorials/crontrigger).
 
@@ -60,6 +61,11 @@ Or install it yourself as:
 
     Cronex::ExpressionDescriptor.new('30 2 * 2 1-5', {}, 'fr').description
     => À 2:30 AM, lundi à vendredi, seulement en février
+
+#### Timezones
+
+    Cronex::ExpressionDescriptor.new('0-10 11 * * *', timezone: 'America/Los_Angeles').description
+    => Every minute between 3:00 AM and 3:10 AM
 
 See spec tests for more examples.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Or install it yourself as:
 
 #### Timezones
 
-    Cronex::ExpressionDescriptor.new('0-10 11 * * *', timezone: 'America/Los_Angeles').description
+    Cronex::ExpressionDescriptor.new('0-10 11 * * *', {}, 'en', 'America/Los_Angeles').description
     => Every minute between 4:00 AM and 4:10 AM # PDT or
     => Every minute between 3:00 AM and 3:10 AM # PST
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Or install it yourself as:
 #### Timezones
 
     Cronex::ExpressionDescriptor.new('0-10 11 * * *', timezone: 'America/Los_Angeles').description
-    => Every minute between 3:00 AM and 3:10 AM
+    => Every minute between 5:00 AM and 5:10 AM # PDT or
+    => Every minute between 4:00 AM and 4:10 AM # PST
 
 See spec tests for more examples.
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Or install it yourself as:
 #### Timezones
 
     Cronex::ExpressionDescriptor.new('0-10 11 * * *', timezone: 'America/Los_Angeles').description
-    => Every minute between 5:00 AM and 5:10 AM # PDT or
-    => Every minute between 4:00 AM and 4:10 AM # PST
+    => Every minute between 4:00 AM and 4:10 AM # PDT or
+    => Every minute between 3:00 AM and 3:10 AM # PST
 
 See spec tests for more examples.
 

--- a/cronex.gemspec
+++ b/cronex.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']
 
+  spec.add_runtime_dependency 'tzinfo', '~> 1.2.5'
   spec.add_runtime_dependency 'unicode'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '~> 10.1'

--- a/lib/cronex/description/hours.rb
+++ b/lib/cronex/description/hours.rb
@@ -1,7 +1,7 @@
 module Cronex
   class HoursDescription < Description
-    def single_item_description(expression)
-      Cronex::Utils.format_time(expression, '0')
+    def single_item_description(expression, timezone = 'UTC')
+      Cronex::Utils.format_time(expression, '0', '', timezone)
     end
 
     def interval_description_format(expression)

--- a/lib/cronex/exp_descriptor.rb
+++ b/lib/cronex/exp_descriptor.rb
@@ -142,7 +142,7 @@ module Cronex
         # Hours list with single minute (e.g. 30 6,14,16)
         hour_parts = hour_exp.split(',')
         description += resources.get('at')
-        h_parts = hour_parts.map { |part| ' ' + Cronex::Utils.format_time(part, min_exp) }
+        h_parts = hour_parts.map { |part| ' ' + Cronex::Utils.format_time(part, min_exp, '', options[:timezone]) }
         description += h_parts[0...-1].join(',') + ' ' + resources.get('and') + h_parts.last
       else
         sec_desc = seconds_description(expression_parts)

--- a/lib/cronex/exp_descriptor.rb
+++ b/lib/cronex/exp_descriptor.rb
@@ -12,19 +12,19 @@ module Cronex
     verbose: false,
     zero_based_dow: true,
     use_24_hour_time_format: false,
-    throw_exception_on_parse_error: true,
-    timezone: 'UTC'
+    throw_exception_on_parse_error: true
   }
 
   class ExpressionDescriptor
     attr_accessor :expression, :expression_parts, :options, :parsed, :resources
 
-    def initialize(expression, options = {}, locale = nil)
+    def initialize(expression, options = {}, locale = nil, timezone = 'UTC')
       @expression = expression
       @options = CRONEX_OPTS.merge(options)
       @expression_parts = []
       @parsed = false
       @resources = Cronex::Resource.new(locale)
+      @timezone = timezone
     end
 
     def to_hash
@@ -130,19 +130,19 @@ module Cronex
       description = ''
       if [sec_exp, min_exp, hour_exp].all? { |exp| !Cronex::Utils.include_any?(exp, SPECIAL_CHARS) }
         # specific time of day (i.e. 10 14)
-        description += resources.get('at') + ' ' + Cronex::Utils.format_time(hour_exp, min_exp, sec_exp, options[:timezone])
+        description += resources.get('at') + ' ' + Cronex::Utils.format_time(hour_exp, min_exp, sec_exp, @timezone)
       elsif min_exp.include?('-') && !min_exp.include?('/') && !min_exp.include?(',') && !Cronex::Utils.include_any?(hour_exp, SPECIAL_CHARS)
         # Minute range in single hour (e.g. 0-10 11)
         min_parts = min_exp.split('-')
         description += format(
           resources.get('every_minute_between'),
-          Cronex::Utils.format_time(hour_exp, min_parts[0], '', options[:timezone]),
-          Cronex::Utils.format_time(hour_exp, min_parts[1], '', options[:timezone]))
+          Cronex::Utils.format_time(hour_exp, min_parts[0], '', @timezone),
+          Cronex::Utils.format_time(hour_exp, min_parts[1], '', @timezone))
       elsif hour_exp.include?(',') && !Cronex::Utils.include_any?(min_exp, SPECIAL_CHARS)
         # Hours list with single minute (e.g. 30 6,14,16)
         hour_parts = hour_exp.split(',')
         description += resources.get('at')
-        h_parts = hour_parts.map { |part| ' ' + Cronex::Utils.format_time(part, min_exp, '', options[:timezone]) }
+        h_parts = hour_parts.map { |part| ' ' + Cronex::Utils.format_time(part, min_exp, '', @timezone) }
         description += h_parts[0...-1].join(',') + ' ' + resources.get('and') + h_parts.last
       else
         sec_desc = seconds_description(expression_parts)

--- a/lib/cronex/exp_descriptor.rb
+++ b/lib/cronex/exp_descriptor.rb
@@ -16,7 +16,7 @@ module Cronex
   }
 
   class ExpressionDescriptor
-    attr_accessor :expression, :expression_parts, :options, :parsed, :resources
+    attr_accessor :expression, :expression_parts, :options, :parsed, :resources, :timezone
 
     def initialize(expression, options = {}, locale = nil, timezone = 'UTC')
       @expression = expression
@@ -130,19 +130,19 @@ module Cronex
       description = ''
       if [sec_exp, min_exp, hour_exp].all? { |exp| !Cronex::Utils.include_any?(exp, SPECIAL_CHARS) }
         # specific time of day (i.e. 10 14)
-        description += resources.get('at') + ' ' + Cronex::Utils.format_time(hour_exp, min_exp, sec_exp, @timezone)
+        description += resources.get('at') + ' ' + Cronex::Utils.format_time(hour_exp, min_exp, sec_exp, timezone)
       elsif min_exp.include?('-') && !min_exp.include?('/') && !min_exp.include?(',') && !Cronex::Utils.include_any?(hour_exp, SPECIAL_CHARS)
         # Minute range in single hour (e.g. 0-10 11)
         min_parts = min_exp.split('-')
         description += format(
           resources.get('every_minute_between'),
-          Cronex::Utils.format_time(hour_exp, min_parts[0], '', @timezone),
-          Cronex::Utils.format_time(hour_exp, min_parts[1], '', @timezone))
+          Cronex::Utils.format_time(hour_exp, min_parts[0], '', timezone),
+          Cronex::Utils.format_time(hour_exp, min_parts[1], '', timezone))
       elsif hour_exp.include?(',') && !Cronex::Utils.include_any?(min_exp, SPECIAL_CHARS)
         # Hours list with single minute (e.g. 30 6,14,16)
         hour_parts = hour_exp.split(',')
         description += resources.get('at')
-        h_parts = hour_parts.map { |part| ' ' + Cronex::Utils.format_time(part, min_exp, '', @timezone) }
+        h_parts = hour_parts.map { |part| ' ' + Cronex::Utils.format_time(part, min_exp, '', timezone) }
         description += h_parts[0...-1].join(',') + ' ' + resources.get('and') + h_parts.last
       else
         sec_desc = seconds_description(expression_parts)

--- a/lib/cronex/exp_descriptor.rb
+++ b/lib/cronex/exp_descriptor.rb
@@ -12,7 +12,8 @@ module Cronex
     verbose: false,
     zero_based_dow: true,
     use_24_hour_time_format: false,
-    throw_exception_on_parse_error: true
+    throw_exception_on_parse_error: true,
+    timezone: 'UTC'
   }
 
   class ExpressionDescriptor
@@ -129,14 +130,14 @@ module Cronex
       description = ''
       if [sec_exp, min_exp, hour_exp].all? { |exp| !Cronex::Utils.include_any?(exp, SPECIAL_CHARS) }
         # specific time of day (i.e. 10 14)
-        description += resources.get('at') + ' ' + Cronex::Utils.format_time(hour_exp, min_exp, sec_exp)
+        description += resources.get('at') + ' ' + Cronex::Utils.format_time(hour_exp, min_exp, sec_exp, options[:timezone])
       elsif min_exp.include?('-') && !min_exp.include?('/') && !min_exp.include?(',') && !Cronex::Utils.include_any?(hour_exp, SPECIAL_CHARS)
         # Minute range in single hour (e.g. 0-10 11)
         min_parts = min_exp.split('-')
         description += format(
           resources.get('every_minute_between'),
-          Cronex::Utils.format_time(hour_exp, min_parts[0]),
-          Cronex::Utils.format_time(hour_exp, min_parts[1]))
+          Cronex::Utils.format_time(hour_exp, min_parts[0], '', options[:timezone]),
+          Cronex::Utils.format_time(hour_exp, min_parts[1], '', options[:timezone]))
       elsif hour_exp.include?(',') && !Cronex::Utils.include_any?(min_exp, SPECIAL_CHARS)
         # Hours list with single minute (e.g. 30 6,14,16)
         hour_parts = hour_exp.split(',')

--- a/lib/cronex/utils.rb
+++ b/lib/cronex/utils.rb
@@ -1,3 +1,5 @@
+require 'tzinfo'
+
 module Cronex
   module Utils
     extend self
@@ -17,7 +19,7 @@ module Cronex
     def integer(str)
       # strip leading zeros in numbers to prevent '08', '09'
       # from being treated as invalid octals
-      Integer(str.sub(/^0*(\d+)/, '\1'))
+      Integer(str.sub(/^0*(\d+)/, '\1')) rescue 0
     end
 
     def day_of_week_name(number)
@@ -32,18 +34,14 @@ module Cronex
       end
     end
 
-    def format_time(hour_expression, minute_expression, second_expression = '')
+    def format_time(hour_expression, minute_expression, second_expression = '', timezone = 'UTC')
       hour = integer(hour_expression)
-      period = hour >= 12 ? 'PM' : 'AM'
-      hour -= 12 if hour > 12
       minute = integer(minute_expression)
-      minute = format('%02d', minute)
-      second = ''
-      if present?(second_expression)
-        second = integer(second_expression)
-        second = ':' + format('%02d', second)
-      end
-      format('%s:%s%s %s', hour, minute, second, period)
+      second = integer(second_expression)
+      tz = TZInfo::Timezone.get(timezone)
+      time = tz.utc_to_local(Time.utc(2000, 1, 1, hour, minute, second))
+      format = present?(second_expression) ? '%l:%M:%S %p' : '%l:%M %p'
+      time.strftime(format).lstrip
     end
   end
 end

--- a/lib/cronex/utils.rb
+++ b/lib/cronex/utils.rb
@@ -39,7 +39,7 @@ module Cronex
       minute = integer(minute_expression)
       second = integer(second_expression)
       tz = TZInfo::Timezone.get(timezone)
-      time = tz.utc_to_local(Time.utc(2000, 1, 1, hour, minute, second))
+      time = tz.utc_to_local(Date.today.to_time + hour * 60 * 60 + minute * 60 + second)
       format = present?(second_expression) ? '%l:%M:%S %p' : '%l:%M %p'
       time.strftime(format).lstrip
     end

--- a/lib/cronex/utils.rb
+++ b/lib/cronex/utils.rb
@@ -37,7 +37,7 @@ module Cronex
     def format_time(hour_expression, minute_expression, second_expression = '', timezone = 'UTC')
       hour = integer(hour_expression)
       minute = integer(minute_expression)
-      second = second_expression == '' ? 0 : integer(second_expression)
+      second = second_expression.to_s.empty? ? 0 : integer(second_expression)
       tz = TZInfo::Timezone.get(timezone)
       time = tz.utc_to_local(Date.today.to_time + hour * 60 * 60 + minute * 60 + second)
       format = present?(second_expression) ? '%l:%M:%S %p' : '%l:%M %p'

--- a/lib/cronex/utils.rb
+++ b/lib/cronex/utils.rb
@@ -19,7 +19,7 @@ module Cronex
     def integer(str)
       # strip leading zeros in numbers to prevent '08', '09'
       # from being treated as invalid octals
-      Integer(str.sub(/^0*(\d+)/, '\1')) rescue 0
+      Integer(str.sub(/^0*(\d+)/, '\1'))
     end
 
     def day_of_week_name(number)
@@ -37,7 +37,7 @@ module Cronex
     def format_time(hour_expression, minute_expression, second_expression = '', timezone = 'UTC')
       hour = integer(hour_expression)
       minute = integer(minute_expression)
-      second = integer(second_expression)
+      second = second_expression == '' ? 0 : integer(second_expression)
       tz = TZInfo::Timezone.get(timezone)
       time = tz.utc_to_local(Date.today.to_time + hour * 60 * 60 + minute * 60 + second)
       format = present?(second_expression) ? '%l:%M:%S %p' : '%l:%M %p'

--- a/lib/cronex/version.rb
+++ b/lib/cronex/version.rb
@@ -1,3 +1,3 @@
 module Cronex
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end

--- a/spec/exp_descriptor_en_spec.rb
+++ b/spec/exp_descriptor_en_spec.rb
@@ -383,11 +383,21 @@ module Cronex
       it 'minute span' do
         tz = TZInfo::Timezone.get('America/Los_Angeles')
         result = if tz.period_for_local(Time.now).zone_identifier.to_s == 'PDT'
-                   'Every minute between 3:00 AM and 3:10 AM'
+                   'Every minute between 4:00 AM and 4:10 AM'
                  else
-                   'Every minute between 2:00 AM and 2:10 AM'
+                   'Every minute between 3:00 AM and 3:10 AM'
                  end
         expect(desc('0-10 11 * * *', timezone: 'America/Los_Angeles')).to eq(result)
+      end
+
+      it 'twice a day' do
+        tz = TZInfo::Timezone.get('America/Los_Angeles')
+        result = if tz.period_for_local(Time.now).zone_identifier.to_s == 'PDT'
+                   'At 5:00 PM and 5:00 AM'
+                 else
+                   'At 4:00 PM and 4:00 AM'
+                 end
+        expect(desc('0 0,12 * * *', timezone: 'America/Los_Angeles')).to eq(result)
       end
     end
   end

--- a/spec/exp_descriptor_en_spec.rb
+++ b/spec/exp_descriptor_en_spec.rb
@@ -375,7 +375,19 @@ module Cronex
       end
 
       it 'year increments' do
-        expect(desc('0 0 0 1 MAR * 2010/5')).to eq('At 0:00 AM, on day 1 of the month, only in March, every 5 years, starting in 2010')
+        expect(desc('0 0 0 1 MAR * 2010/5')).to eq('At 12:00 AM, on day 1 of the month, only in March, every 5 years, starting in 2010')
+      end
+    end
+
+    context 'timezone' do
+      it 'minute span' do
+        tz = TZInfo::Timezone.get('America/Los_Angeles')
+        result = if tz.period_for_local(Time.now).zone_identifier.to_s == 'PDT'
+                   'Every minute between 3:00 AM and 3:10 AM'
+                 else
+                   'Every minute between 2:00 AM and 2:10 AM'
+                 end
+        expect(desc('0-10 11 * * *', timezone: 'America/Los_Angeles')).to eq(result)
       end
     end
   end

--- a/spec/exp_descriptor_en_spec.rb
+++ b/spec/exp_descriptor_en_spec.rb
@@ -4,8 +4,8 @@ require 'cronex'
 module Cronex
   describe ExpressionDescriptor do
 
-    def desc(expression, opts = {})
-      Cronex::ExpressionDescriptor.new(expression, opts, 'en').description
+    def desc(expression, opts = {}, timezone = 'UTC')
+      Cronex::ExpressionDescriptor.new(expression, opts, 'en', timezone).description
     end
 
     let(:opts) { { zero_based_dow: false } }
@@ -382,22 +382,14 @@ module Cronex
     context 'timezone' do
       it 'minute span' do
         tz = TZInfo::Timezone.get('America/Los_Angeles')
-        result = if tz.period_for_local(Time.now).zone_identifier.to_s == 'PDT'
-                   'Every minute between 4:00 AM and 4:10 AM'
-                 else
-                   'Every minute between 3:00 AM and 3:10 AM'
-                 end
-        expect(desc('0-10 11 * * *', timezone: 'America/Los_Angeles')).to eq(result)
+        hour = tz.period_for_local(Time.now).zone_identifier.to_s == 'PDT' ? 4 : 3
+        expect(desc('0-10 11 * * *', {}, 'America/Los_Angeles')).to eq("Every minute between #{hour}:00 AM and #{hour}:10 AM")
       end
 
       it 'twice a day' do
         tz = TZInfo::Timezone.get('America/Los_Angeles')
-        result = if tz.period_for_local(Time.now).zone_identifier.to_s == 'PDT'
-                   'At 5:00 PM and 5:00 AM'
-                 else
-                   'At 4:00 PM and 4:00 AM'
-                 end
-        expect(desc('0 0,12 * * *', timezone: 'America/Los_Angeles')).to eq(result)
+        hour = tz.period_for_local(Time.now).zone_identifier.to_s == 'PDT' ? 5 : 4
+        expect(desc('0 0,12 * * *', {}, 'America/Los_Angeles')).to eq("At #{hour}:00 PM and #{hour}:00 AM")
       end
     end
   end

--- a/spec/exp_descriptor_en_spec.rb
+++ b/spec/exp_descriptor_en_spec.rb
@@ -391,6 +391,12 @@ module Cronex
         hour = tz.period_for_local(Time.now).zone_identifier.to_s == 'PDT' ? 5 : 4
         expect(desc('0 0,12 * * *', {}, 'America/Los_Angeles')).to eq("At #{hour}:00 PM and #{hour}:00 AM")
       end
+
+      it 'ahead of GMT' do
+        tz = TZInfo::Timezone.get('Europe/Vienna')
+        hour = tz.period_for_local(Time.now).zone_identifier.to_s == 'CEST' ? 1 : 12
+        expect(desc('0-10 11 * * *', {}, 'Europe/Vienna')).to eq("Every minute between #{hour}:00 PM and #{hour}:10 PM")
+      end
     end
   end
 end

--- a/spec/exp_descriptor_fr_spec.rb
+++ b/spec/exp_descriptor_fr_spec.rb
@@ -375,7 +375,7 @@ module Cronex
       end
 
       it 'year increments' do
-        expect(desc('0 0 0 1 MAR * 2010/5')).to eq('À 0:00 AM, le 1 de chaque mois, seulement en mars, tous les 5 ans, commence en 2010')
+        expect(desc('0 0 0 1 MAR * 2010/5')).to eq('À 12:00 AM, le 1 de chaque mois, seulement en mars, tous les 5 ans, commence en 2010')
       end
     end
   end

--- a/spec/exp_descriptor_pt_BR_spec.rb
+++ b/spec/exp_descriptor_pt_BR_spec.rb
@@ -375,7 +375,7 @@ module Cronex
       end
 
       it 'year increments' do
-        expect(desc('0 0 0 1 MAR * 2010/5')).to eq('Às 0:00 AM, no dia 1 do mês, em março, a cada 5 anos, iniciando em 2010')
+        expect(desc('0 0 0 1 MAR * 2010/5')).to eq('Às 12:00 AM, no dia 1 do mês, em março, a cada 5 anos, iniciando em 2010')
       end
     end
   end

--- a/spec/exp_descriptor_ro_spec.rb
+++ b/spec/exp_descriptor_ro_spec.rb
@@ -375,7 +375,7 @@ module Cronex
       end
 
       it 'year increments' do
-        expect(desc('0 0 0 1 MAR * 2010/5')).to eq('La 0:00 AM, în a 1-a zi a lunii, numai în martie, la fiecare 5 ani, pornire în 2010')
+        expect(desc('0 0 0 1 MAR * 2010/5')).to eq('La 12:00 AM, în a 1-a zi a lunii, numai în martie, la fiecare 5 ani, pornire în 2010')
       end
     end
   end

--- a/spec/exp_descriptor_ru_spec.rb
+++ b/spec/exp_descriptor_ru_spec.rb
@@ -375,7 +375,7 @@ module Cronex
       end
 
       it 'year increments' do
-        expect(desc('0 0 0 1 MAR * 2010/5')).to eq('В 0:00 AM, 1 число месяца, только март, каждые 5 лет, начало в 2010')
+        expect(desc('0 0 0 1 MAR * 2010/5')).to eq('В 12:00 AM, 1 число месяца, только март, каждые 5 лет, начало в 2010')
       end
     end
   end


### PR DESCRIPTION
#### Why
Many cron jobs are run on cloud servers with UTC timezone. It's useful to display human-readable schedules in local time.

#### Example usage
```
    Cronex::ExpressionDescriptor.new('0-10 11 * * *', timezone: 'America/Los_Angeles').description
    => Every minute between 3:00 AM and 3:10 AM
```