### PR TITLE
Move locale and timezone arguments to options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### [0.10.0] - 2020-05-26
+* Move locale and timezone arguments to options
+
 ### [0.9.2] - 2020-04-24
 * Add italian locale
 

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ Or install it yourself as:
 
 #### Localization
 
-    Cronex::ExpressionDescriptor.new('30 2 * 2 1-5', {}, 'fr').description
+    Cronex::ExpressionDescriptor.new('30 2 * 2 1-5', locale: 'fr').description
     => À 2:30 AM, lundi à vendredi, seulement en février
 
 #### Timezones
 
-    Cronex::ExpressionDescriptor.new('0-10 11 * * *', {}, 'en', 'America/Los_Angeles').description
+    Cronex::ExpressionDescriptor.new('0-10 11 * * *', timezone: 'America/Los_Angeles').description
     => Every minute between 4:00 AM and 4:10 AM # PDT or
     => Every minute between 3:00 AM and 3:10 AM # PST
 

--- a/lib/cronex/exp_descriptor.rb
+++ b/lib/cronex/exp_descriptor.rb
@@ -12,19 +12,21 @@ module Cronex
     verbose: false,
     zero_based_dow: true,
     use_24_hour_time_format: false,
-    throw_exception_on_parse_error: true
+    throw_exception_on_parse_error: true,
+    locale: nil,
+    timezone: nil
   }
 
   class ExpressionDescriptor
     attr_accessor :expression, :expression_parts, :options, :parsed, :resources, :timezone
 
-    def initialize(expression, options = {}, locale = nil, timezone = 'UTC')
+    def initialize(expression, options = {})
       @expression = expression
       @options = CRONEX_OPTS.merge(options)
       @expression_parts = []
       @parsed = false
-      @resources = Cronex::Resource.new(locale)
-      @timezone = timezone
+      @resources = Cronex::Resource.new(@options[:locale])
+      @timezone = @options[:timezone] || 'UTC'
     end
 
     def to_hash

--- a/lib/cronex/version.rb
+++ b/lib/cronex/version.rb
@@ -1,3 +1,3 @@
 module Cronex
-  VERSION = '0.9.2'
+  VERSION = '0.10.0'
 end

--- a/spec/exp_descriptor_de_spec.rb
+++ b/spec/exp_descriptor_de_spec.rb
@@ -4,8 +4,9 @@ require 'cronex'
 module Cronex
   describe ExpressionDescriptor do
 
-    def desc(expression, opts = {}, timezone = 'UTC')
-      Cronex::ExpressionDescriptor.new(expression, opts, 'de', timezone).description
+    def desc(expression, opts = {})
+      opts[:locale] = 'de'
+      Cronex::ExpressionDescriptor.new(expression, opts).description
     end
 
     let(:opts) { { zero_based_dow: false } }

--- a/spec/exp_descriptor_en_spec.rb
+++ b/spec/exp_descriptor_en_spec.rb
@@ -4,8 +4,9 @@ require 'cronex'
 module Cronex
   describe ExpressionDescriptor do
 
-    def desc(expression, opts = {}, timezone = 'UTC')
-      Cronex::ExpressionDescriptor.new(expression, opts, 'en', timezone).description
+    def desc(expression, opts = {})
+      opts[:locale] = 'en'
+      Cronex::ExpressionDescriptor.new(expression, opts).description
     end
 
     let(:opts) { { zero_based_dow: false } }
@@ -383,19 +384,19 @@ module Cronex
       it 'minute span' do
         tz = TZInfo::Timezone.get('America/Los_Angeles')
         hour = tz.period_for_local(Time.now).zone_identifier.to_s == 'PDT' ? 4 : 3
-        expect(desc('0-10 11 * * *', {}, 'America/Los_Angeles')).to eq("Every minute between #{hour}:00 AM and #{hour}:10 AM")
+        expect(desc('0-10 11 * * *', timezone: 'America/Los_Angeles')).to eq("Every minute between #{hour}:00 AM and #{hour}:10 AM")
       end
 
       it 'twice a day' do
         tz = TZInfo::Timezone.get('America/Los_Angeles')
         hour = tz.period_for_local(Time.now).zone_identifier.to_s == 'PDT' ? 5 : 4
-        expect(desc('0 0,12 * * *', {}, 'America/Los_Angeles')).to eq("At #{hour}:00 PM and #{hour}:00 AM")
+        expect(desc('0 0,12 * * *', timezone: 'America/Los_Angeles')).to eq("At #{hour}:00 PM and #{hour}:00 AM")
       end
 
       it 'ahead of GMT' do
         tz = TZInfo::Timezone.get('Europe/Vienna')
         hour = tz.period_for_local(Time.now).zone_identifier.to_s == 'CEST' ? 1 : 12
-        expect(desc('0-10 11 * * *', {}, 'Europe/Vienna')).to eq("Every minute between #{hour}:00 PM and #{hour}:10 PM")
+        expect(desc('0-10 11 * * *', timezone: 'Europe/Vienna')).to eq("Every minute between #{hour}:00 PM and #{hour}:10 PM")
       end
     end
   end

--- a/spec/exp_descriptor_fr_spec.rb
+++ b/spec/exp_descriptor_fr_spec.rb
@@ -5,7 +5,8 @@ module Cronex
   describe ExpressionDescriptor do
 
     def desc(expression, opts = {})
-      Cronex::ExpressionDescriptor.new(expression, opts, 'fr').description
+      opts[:locale] = 'fr'
+      Cronex::ExpressionDescriptor.new(expression, opts).description
     end
 
     let(:opts) { { zero_based_dow: false } }

--- a/spec/exp_descriptor_it_spec.rb
+++ b/spec/exp_descriptor_it_spec.rb
@@ -4,8 +4,9 @@ require 'cronex'
 module Cronex
   describe ExpressionDescriptor do
 
-    def desc(expression, opts = {}, timezone = 'UTC')
-      Cronex::ExpressionDescriptor.new(expression, opts, 'it', timezone).description
+    def desc(expression, opts = {})
+      opts[:locale] = 'it'
+      Cronex::ExpressionDescriptor.new(expression, opts).description
     end
 
     let(:opts) { { zero_based_dow: false } }
@@ -376,26 +377,6 @@ module Cronex
 
       it 'year increments' do
         expect(desc('0 0 0 1 MAR * 2010/5')).to eq('Alle(ai) 12:00 AM, il giorno 1 del mese, solo a(nel) marzo, ogni 5 anni, a partire da 2010')
-      end
-    end
-
-    context 'timezone' do
-      it 'minute span' do
-        tz = TZInfo::Timezone.get('America/Los_Angeles')
-        hour = tz.period_for_local(Time.now).zone_identifier.to_s == 'PDT' ? 4 : 3
-        expect(desc('0-10 11 * * *', {}, 'America/Los_Angeles')).to eq("Ogni minuto tra le #{hour}:00 AM e le #{hour}:10 AM")
-      end
-
-      it 'twice a day' do
-        tz = TZInfo::Timezone.get('America/Los_Angeles')
-        hour = tz.period_for_local(Time.now).zone_identifier.to_s == 'PDT' ? 5 : 4
-        expect(desc('0 0,12 * * *', {}, 'America/Los_Angeles')).to eq("Alle(ai) #{hour}:00 PM e #{hour}:00 AM")
-      end
-
-      it 'ahead of GMT' do
-        tz = TZInfo::Timezone.get('Europe/Vienna')
-        hour = tz.period_for_local(Time.now).zone_identifier.to_s == 'CEST' ? 1 : 12
-        expect(desc('0-10 11 * * *', {}, 'Europe/Vienna')).to eq("Ogni minuto tra le #{hour}:00 PM e le #{hour}:10 PM")
       end
     end
   end

--- a/spec/exp_descriptor_pt_BR_spec.rb
+++ b/spec/exp_descriptor_pt_BR_spec.rb
@@ -5,7 +5,8 @@ module Cronex
   describe ExpressionDescriptor do
 
     def desc(expression, opts = {})
-      Cronex::ExpressionDescriptor.new(expression, opts, 'pt_BR').description
+      opts[:locale] = 'pt_BR'
+      Cronex::ExpressionDescriptor.new(expression, opts).description
     end
 
     let(:opts) { { zero_based_dow: false } }

--- a/spec/exp_descriptor_ro_spec.rb
+++ b/spec/exp_descriptor_ro_spec.rb
@@ -5,7 +5,8 @@ module Cronex
   describe ExpressionDescriptor do
 
     def desc(expression, opts = {})
-      Cronex::ExpressionDescriptor.new(expression, opts, 'ro').description
+      opts[:locale] = 'ro'
+      Cronex::ExpressionDescriptor.new(expression, opts).description
     end
 
     let(:opts) { { zero_based_dow: false } }

--- a/spec/exp_descriptor_ru_spec.rb
+++ b/spec/exp_descriptor_ru_spec.rb
@@ -5,7 +5,8 @@ module Cronex
   describe ExpressionDescriptor do
 
     def desc(expression, opts = {})
-      Cronex::ExpressionDescriptor.new(expression, opts, 'ru').description
+      opts[:locale] = 'ru'
+      Cronex::ExpressionDescriptor.new(expression, opts).description
     end
 
     let(:opts) { { zero_based_dow: false } }


### PR DESCRIPTION
This is to address issue #17 .
It's a potentially breaking change as it changes the calling signature of `Cronex::ExpressionDescriptor.new`