### PR TITLE
 Add an option to specify "strict_quartz" parsing

### DIFF
--- a/lib/cronex/exp_descriptor.rb
+++ b/lib/cronex/exp_descriptor.rb
@@ -14,7 +14,8 @@ module Cronex
     use_24_hour_time_format: false,
     throw_exception_on_parse_error: true,
     locale: nil,
-    timezone: nil
+    timezone: nil,
+    strict_quartz: false
   }
 
   class ExpressionDescriptor

--- a/lib/cronex/parser.rb
+++ b/lib/cronex/parser.rb
@@ -27,6 +27,7 @@ module Cronex
       if len < 5
         fail ExpressionError, "Error: Expression only has #{len} parts. At least 5 parts are required"
       elsif len == 5
+        fail ExpressionError, "Error: Expression only has 5 parts. For 'strict_quartz' option, at least 6 parts are required" if options[:strict_quartz]
         # 5 part CRON so shift array past seconds element
         parsed_parts.insert(1, *parts)
       elsif len == 6

--- a/spec/exp_descriptor_en_spec.rb
+++ b/spec/exp_descriptor_en_spec.rb
@@ -390,6 +390,12 @@ module Cronex
       end
     end
 
+    context 'strict_quartz' do
+      it '5 part cron fails' do
+        expect { desc('* * * * *', { strict_quartz: true }) }.to raise_error(Cronex::ExpressionError)
+      end
+    end
+
     context 'timezone' do
       it 'minute span' do
         tz = TZInfo::Timezone.get('America/Los_Angeles')


### PR DESCRIPTION
If you are using a Java Quartz implementation (quartz-scheduler), 5 params not allowed (and *should* be a parsing error).

Add an option to specify "strict_quartz" parsing, and raise an exception if there are only 5 params.