### PR TITLE
Fix zero hour

### DIFF
--- a/lib/cronex/description/base.rb
+++ b/lib/cronex/description/base.rb
@@ -13,7 +13,7 @@ module Cronex
     end
 
     def segment_description(expression, all_values_description)
-      if expression.empty? || expression == '0'
+      if expression.empty? || (expression == '0' && self.class != Cronex::HoursDescription)
         desc = ''
       elsif expression == '*'
         desc = all_values_description

--- a/spec/exp_descriptor_de_spec.rb
+++ b/spec/exp_descriptor_de_spec.rb
@@ -333,22 +333,30 @@ module Cronex
     end
 
     context 'minutes past the hour:' do
+      it 'minutes past the hour 5,10, midnight hour' do
+        expect(desc('5,10 0 * * *')).to eq('Um 05 und 10 Minuten vergangene Stunde, um 12:00 AM')
+      end
+
       it 'minutes past the hour 5,10' do
-        expect(desc('5,10 0 * * *')).to eq('Um 05 und 10 Minuten vergangene Stunde')
+        expect(desc('5,10 * * * *')).to eq('Um 05 und 10 Minuten vergangene Stunde')
       end
 
       it 'minutes past the hour 5,10 day 2' do
-        expect(desc('5,10 0 2 * *')).to eq('Um 05 und 10 Minuten vergangene Stunde, am 2 Tag des Monats')
+        expect(desc('5,10 * 2 * *')).to eq('Um 05 und 10 Minuten vergangene Stunde, am 2 Tag des Monats')
       end
 
       it 'minutes past the hour 5/10 day 2' do
-        expect(desc('5/10 0 2 * *')).to eq('Alle 10 Minuten, beginnend um 05 Minuten vergangene Stunde, am 2 Tag des Monats')
+        expect(desc('5/10 * 2 * *')).to eq('Alle 10 Minuten, beginnend um 05 Minuten vergangene Stunde, am 2 Tag des Monats')
       end
     end
 
     context 'seconds past the minute:' do
+      it 'seconds past the minute 5,6, midnight hour' do
+        expect(desc('5,6 0 0 * * *')).to eq('Am 5 und 6 Sekunden nach der vergangenen Minute, um 12:00 AM')
+      end
+
       it 'seconds past the minute 5,6' do
-        expect(desc('5,6 0 0 * * *')).to eq('Am 5 und 6 Sekunden nach der vergangenen Minute')
+        expect(desc('5,6 0 * * * *')).to eq('Am 5 und 6 Sekunden nach der vergangenen Minute')
       end
 
       it 'seconds past the minute 5,6 at 1' do
@@ -356,7 +364,7 @@ module Cronex
       end
 
       it 'seconds past the minute 5,6 day 2' do
-        expect(desc('5,6 0 0 2 * *')).to eq('Am 5 und 6 Sekunden nach der vergangenen Minute, am 2 Tag des Monats')
+        expect(desc('5,6 0 * 2 * *')).to eq('Am 5 und 6 Sekunden nach der vergangenen Minute, am 2 Tag des Monats')
       end
     end
 

--- a/spec/exp_descriptor_en_spec.rb
+++ b/spec/exp_descriptor_en_spec.rb
@@ -42,6 +42,10 @@ module Cronex
         expect(desc('*/5 * * * *')).to eq('Every 5 minutes')
       end
 
+      it 'every 5 minutes at Midnight' do
+        expect(desc('*/5 0 * * *')).to eq('Every 5 minutes, at 12:00 AM')
+      end
+
       it 'every 5 minute 0 */5' do
         expect(desc('0 */5 * * * *')).to eq('Every 5 minutes')
       end
@@ -333,22 +337,30 @@ module Cronex
     end
 
     context 'minutes past the hour:' do
+      it 'minutes past the hour 5,10, midnight hour' do
+        expect(desc('5,10 0 * * *')).to eq('At 05 and 10 minutes past the hour, at 12:00 AM')
+      end
+
       it 'minutes past the hour 5,10' do
-        expect(desc('5,10 0 * * *')).to eq('At 05 and 10 minutes past the hour')
+        expect(desc('5,10 * * * *')).to eq('At 05 and 10 minutes past the hour')
       end
 
       it 'minutes past the hour 5,10 day 2' do
-        expect(desc('5,10 0 2 * *')).to eq('At 05 and 10 minutes past the hour, on day 2 of the month')
+        expect(desc('5,10 * 2 * *')).to eq('At 05 and 10 minutes past the hour, on day 2 of the month')
       end
 
       it 'minutes past the hour 5/10 day 2' do
-        expect(desc('5/10 0 2 * *')).to eq('Every 10 minutes, starting at 05 minutes past the hour, on day 2 of the month')
+        expect(desc('5/10 * 2 * *')).to eq('Every 10 minutes, starting at 05 minutes past the hour, on day 2 of the month')
       end
     end
 
     context 'seconds past the minute:' do
+      it 'seconds past the minute 5,6, midnight hour' do
+        expect(desc('5,6 0 0 * * *')).to eq('At 5 and 6 seconds past the minute, at 12:00 AM')
+      end
+
       it 'seconds past the minute 5,6' do
-        expect(desc('5,6 0 0 * * *')).to eq('At 5 and 6 seconds past the minute')
+        expect(desc('5,6 0 * * * *')).to eq('At 5 and 6 seconds past the minute')
       end
 
       it 'seconds past the minute 5,6 at 1' do
@@ -356,7 +368,7 @@ module Cronex
       end
 
       it 'seconds past the minute 5,6 day 2' do
-        expect(desc('5,6 0 0 2 * *')).to eq('At 5 and 6 seconds past the minute, on day 2 of the month')
+        expect(desc('5,6 0 * 2 * *')).to eq('At 5 and 6 seconds past the minute, on day 2 of the month')
       end
     end
 

--- a/spec/exp_descriptor_fr_spec.rb
+++ b/spec/exp_descriptor_fr_spec.rb
@@ -333,22 +333,30 @@ module Cronex
     end
 
     context 'minutes past the hour:' do
+      it 'minutes past the hour 5,10, midnight hour' do
+        expect(desc('5,10 0 * * *')).to eq("À 05 et 10 minutes après l'heure, à 12:00 AM")
+      end
+
       it 'minutes past the hour 5,10' do
-        expect(desc('5,10 0 * * *')).to eq("À 05 et 10 minutes après l'heure")
+        expect(desc('5,10 * * * *')).to eq("À 05 et 10 minutes après l'heure")
       end
 
       it 'minutes past the hour 5,10 day 2' do
-        expect(desc('5,10 0 2 * *')).to eq("À 05 et 10 minutes après l'heure, le 2 de chaque mois")
+        expect(desc('5,10 * 2 * *')).to eq("À 05 et 10 minutes après l'heure, le 2 de chaque mois")
       end
 
       it 'minutes past the hour 5/10 day 2' do
-        expect(desc('5/10 0 2 * *')).to eq("Tous les 10 minutes, commence à 05 minutes après l'heure, le 2 de chaque mois")
+        expect(desc('5/10 * 2 * *')).to eq("Tous les 10 minutes, commence à 05 minutes après l'heure, le 2 de chaque mois")
       end
     end
 
     context 'seconds past the minute:' do
+      it 'seconds past the minute 5,6, midnight hour' do
+        expect(desc('5,6 0 0 * * *')).to eq('À 5 et 6 secondes après la minute, à 12:00 AM')
+      end
+
       it 'seconds past the minute 5,6' do
-        expect(desc('5,6 0 0 * * *')).to eq('À 5 et 6 secondes après la minute')
+        expect(desc('5,6 0 * * * *')).to eq('À 5 et 6 secondes après la minute')
       end
 
       it 'seconds past the minute 5,6 at 1' do
@@ -356,7 +364,7 @@ module Cronex
       end
 
       it 'seconds past the minute 5,6 day 2' do
-        expect(desc('5,6 0 0 2 * *')).to eq('À 5 et 6 secondes après la minute, le 2 de chaque mois')
+        expect(desc('5,6 0 * 2 * *')).to eq('À 5 et 6 secondes après la minute, le 2 de chaque mois')
       end
     end
 

--- a/spec/exp_descriptor_it_spec.rb
+++ b/spec/exp_descriptor_it_spec.rb
@@ -333,22 +333,30 @@ module Cronex
     end
 
     context 'minutes past the hour:' do
+      it 'minutes past the hour 5,10, midnight hour' do
+        expect(desc('5,10 0 * * *')).to eq('Alle(ai) 05 e 10 minuti dopo l\'ora, alle(ai) 12:00 AM')
+      end
+
       it 'minutes past the hour 5,10' do
-        expect(desc('5,10 0 * * *')).to eq('Alle(ai) 05 e 10 minuti dopo l\'ora')
+        expect(desc('5,10 * * * *')).to eq('Alle(ai) 05 e 10 minuti dopo l\'ora')
       end
 
       it 'minutes past the hour 5,10 day 2' do
-        expect(desc('5,10 0 2 * *')).to eq('Alle(ai) 05 e 10 minuti dopo l\'ora, il giorno 2 del mese')
+        expect(desc('5,10 * 2 * *')).to eq('Alle(ai) 05 e 10 minuti dopo l\'ora, il giorno 2 del mese')
       end
 
       it 'minutes past the hour 5/10 day 2' do
-        expect(desc('5/10 0 2 * *')).to eq('Ogni 10 minuti, a partire da alle(ai) 05 minuti dopo l\'ora, il giorno 2 del mese')
+        expect(desc('5/10 * 2 * *')).to eq('Ogni 10 minuti, a partire da alle(ai) 05 minuti dopo l\'ora, il giorno 2 del mese')
       end
     end
 
     context 'seconds past the minute:' do
+      it 'seconds past the minute 5,6, midnight hour' do
+        expect(desc('5,6 0 0 * * *')).to eq('A 5 e 6 secondi dopo il minuto, alle(ai) 12:00 AM')
+      end
+
       it 'seconds past the minute 5,6' do
-        expect(desc('5,6 0 0 * * *')).to eq('A 5 e 6 secondi dopo il minuto')
+        expect(desc('5,6 0 * * * *')).to eq('A 5 e 6 secondi dopo il minuto')
       end
 
       it 'seconds past the minute 5,6 at 1' do
@@ -356,7 +364,7 @@ module Cronex
       end
 
       it 'seconds past the minute 5,6 day 2' do
-        expect(desc('5,6 0 0 2 * *')).to eq('A 5 e 6 secondi dopo il minuto, il giorno 2 del mese')
+        expect(desc('5,6 0 * 2 * *')).to eq('A 5 e 6 secondi dopo il minuto, il giorno 2 del mese')
       end
     end
 

--- a/spec/exp_descriptor_pt_BR_spec.rb
+++ b/spec/exp_descriptor_pt_BR_spec.rb
@@ -333,22 +333,30 @@ module Cronex
     end
 
     context 'minutes past the hour:' do
+      it 'minutes past the hour 5,10, midnight hour' do
+        expect(desc('5,10 0 * * *')).to eq('05 e 10 minutos após a hora, 12:00 AM')
+      end
+
       it 'minutes past the hour 5,10' do
-        expect(desc('5,10 0 * * *')).to eq('05 e 10 minutos após a hora')
+        expect(desc('5,10 * * * *')).to eq('05 e 10 minutos após a hora')
       end
 
       it 'minutes past the hour 5,10 day 2' do
-        expect(desc('5,10 0 2 * *')).to eq('05 e 10 minutos após a hora, no dia 2 do mês')
+        expect(desc('5,10 * 2 * *')).to eq('05 e 10 minutos após a hora, no dia 2 do mês')
       end
 
       it 'minutes past the hour 5/10 day 2' do
-        expect(desc('5/10 0 2 * *')).to eq('A cada 10 minutos, iniciando 05 minutos após a hora, no dia 2 do mês')
+        expect(desc('5/10 * 2 * *')).to eq('A cada 10 minutos, iniciando 05 minutos após a hora, no dia 2 do mês')
       end
     end
 
     context 'seconds past the minute:' do
+      it 'seconds past the minute 5,6, midnight hour' do
+        expect(desc('5,6 0 0 * * *')).to eq('5 e 6 segundos após o minuto, 12:00 AM')
+      end
+
       it 'seconds past the minute 5,6' do
-        expect(desc('5,6 0 0 * * *')).to eq('5 e 6 segundos após o minuto')
+        expect(desc('5,6 0 * * * *')).to eq('5 e 6 segundos após o minuto')
       end
 
       it 'seconds past the minute 5,6 at 1' do
@@ -356,7 +364,7 @@ module Cronex
       end
 
       it 'seconds past the minute 5,6 day 2' do
-        expect(desc('5,6 0 0 2 * *')).to eq('5 e 6 segundos após o minuto, no dia 2 do mês')
+        expect(desc('5,6 0 * 2 * *')).to eq('5 e 6 segundos após o minuto, no dia 2 do mês')
       end
     end
 

--- a/spec/exp_descriptor_ro_spec.rb
+++ b/spec/exp_descriptor_ro_spec.rb
@@ -333,22 +333,30 @@ module Cronex
     end
 
     context 'minutes past the hour:' do
+      it 'minutes past the hour 5,10, midnight hour' do
+        expect(desc('5,10 0 * * *')).to eq('La 05 și 10 minute în fiecare oră, la 12:00 AM')
+      end
+
       it 'minutes past the hour 5,10' do
-        expect(desc('5,10 0 * * *')).to eq('La 05 și 10 minute în fiecare oră')
+        expect(desc('5,10 * * * *')).to eq('La 05 și 10 minute în fiecare oră')
       end
 
       it 'minutes past the hour 5,10 day 2' do
-        expect(desc('5,10 0 2 * *')).to eq('La 05 și 10 minute în fiecare oră, în a 2-a zi a lunii')
+        expect(desc('5,10 * 2 * *')).to eq('La 05 și 10 minute în fiecare oră, în a 2-a zi a lunii')
       end
 
       it 'minutes past the hour 5/10 day 2' do
-        expect(desc('5/10 0 2 * *')).to eq('La fiecare 10 minute, pornire la 05 minute în fiecare oră, în a 2-a zi a lunii')
+        expect(desc('5/10 * 2 * *')).to eq('La fiecare 10 minute, pornire la 05 minute în fiecare oră, în a 2-a zi a lunii')
       end
     end
 
     context 'seconds past the minute:' do
+      it 'seconds past the minute 5,6, midnight hour' do
+        expect(desc('5,6 0 0 * * *')).to eq('La secunda 5 și 6, la 12:00 AM')
+      end
+
       it 'seconds past the minute 5,6' do
-        expect(desc('5,6 0 0 * * *')).to eq('La secunda 5 și 6')
+        expect(desc('5,6 0 * * * *')).to eq('La secunda 5 și 6')
       end
 
       it 'seconds past the minute 5,6 at 1' do
@@ -356,7 +364,7 @@ module Cronex
       end
 
       it 'seconds past the minute 5,6 day 2' do
-        expect(desc('5,6 0 0 2 * *')).to eq('La secunda 5 și 6, în a 2-a zi a lunii')
+        expect(desc('5,6 0 * 2 * *')).to eq('La secunda 5 și 6, în a 2-a zi a lunii')
       end
     end
 

--- a/spec/exp_descriptor_ru_spec.rb
+++ b/spec/exp_descriptor_ru_spec.rb
@@ -333,22 +333,30 @@ module Cronex
     end
 
     context 'minutes past the hour:' do
+      it 'minutes past the hour 5,10, midnight hour' do
+        expect(desc('5,10 0 * * *')).to eq('В 05 и 10 минут часа, в 12:00 AM')
+      end
+
       it 'minutes past the hour 5,10' do
-        expect(desc('5,10 0 * * *')).to eq('В 05 и 10 минут часа')
+        expect(desc('5,10 * * * *')).to eq('В 05 и 10 минут часа')
       end
 
       it 'minutes past the hour 5,10 day 2' do
-        expect(desc('5,10 0 2 * *')).to eq('В 05 и 10 минут часа, 2 день месяца')
+        expect(desc('5,10 * 2 * *')).to eq('В 05 и 10 минут часа, 2 день месяца')
       end
 
       it 'minutes past the hour 5/10 day 2' do
-        expect(desc('5/10 0 2 * *')).to eq('Каждые 10 минут, начало в 05 минут часа, 2 день месяца')
+        expect(desc('5/10 * 2 * *')).to eq('Каждые 10 минут, начало в 05 минут часа, 2 день месяца')
       end
     end
 
     context 'seconds past the minute:' do
+      it 'seconds past the minute 5,6, midnight hour' do
+        expect(desc('5,6 0 0 * * *')).to eq('В 5 и 6 секунд, в 12:00 AM')
+      end
+
       it 'seconds past the minute 5,6' do
-        expect(desc('5,6 0 0 * * *')).to eq('В 5 и 6 секунд')
+        expect(desc('5,6 0 * * * *')).to eq('В 5 и 6 секунд')
       end
 
       it 'seconds past the minute 5,6 at 1' do
@@ -356,7 +364,7 @@ module Cronex
       end
 
       it 'seconds past the minute 5,6 day 2' do
-        expect(desc('5,6 0 0 2 * *')).to eq('В 5 и 6 секунд, 2 день месяца')
+        expect(desc('5,6 0 * 2 * *')).to eq('В 5 и 6 секунд, 2 день месяца')
       end
     end
 


### PR DESCRIPTION
Prior to this change, both `*` and `0` were treated the same when in the hour position. That meant that the following string:

```
*/5 0 * * *
```

would return the following description:

```
Every 5 minutes
```

Which is incorrect. Instead, cron will run that job every 5 minutes only during the 0th hour. Since `*` means "every hour of the day" but `0` specifically means "the 0th hour" -- midnight, aka 0:00 aka 12:00 AM -- both `*` and `0` cannot be treated equally when in the hour position.

This fixes the parsing such that `0` will properly return what it actually means -- only during the 12:00 AM hour.

Other libraries on which this gem are based do handle this case properly. For example, [the C# version](https://bradymholt.github.io/cron-expression-descriptor/).

# With `*` in hour position

<img width="491" alt="Screen Shot 2023-10-28 at 3 05 40 PM" src="https://github.com/alpinweis/cronex/assets/925/8acb4925-f2cc-4599-9560-45ff1b0642a4">


# With `0` in hour position

<img width="495" alt="Screen Shot 2023-10-28 at 3 05 31 PM" src="https://github.com/alpinweis/cronex/assets/925/4caa750e-f226-49a9-84ee-34ed279965df">

