### PR TITLE
Update unicode to fix bundle install issue with obj taintedness

### DIFF
--- a/cronex.gemspec
+++ b/cronex.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'tzinfo'
-  spec.add_runtime_dependency 'unicode', '~> 0.4.4.5'
+  spec.add_runtime_dependency 'unicode', '>= 0.4.4.5'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.1'

--- a/cronex.gemspec
+++ b/cronex.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'tzinfo'
-  spec.add_runtime_dependency 'unicode'
+  spec.add_runtime_dependency 'unicode', '~> 0.4.4.5'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.1'


### PR DESCRIPTION
I have encountered the issue [described here](https://github.com/blackwinter/unicode/pull/11) in a repo I work on. We depend on cronex which depends on unicode. This PR updates the version of unicode used to prevent the error.